### PR TITLE
hot-fix for race condition fatal

### DIFF
--- a/Source/VoltCore/Private/VoltAnimationManager.cpp
+++ b/Source/VoltCore/Private/VoltAnimationManager.cpp
@@ -252,11 +252,11 @@ void UVoltAnimationManager::Tick(float DeltaTime)
 		if(!AnimationTracks.IsEmpty()) ProcessModuleUpdate(DeltaTime);
 	}
 
-	ApplyVariables();
-
-	// TODO: Provide better way to flush it down, and make sure to this process is not making any bottleneck
+	//These actions must be atomic and done in only one thread.
 	if (!Subsystem->IsModuleUpdateThreadWorking())
 	{
+		ApplyVariables();
+		
 		FlushUnnecessaryTrack();
 	}
 

--- a/Source/VoltCore/Private/VoltSubsystem.cpp
+++ b/Source/VoltCore/Private/VoltSubsystem.cpp
@@ -67,11 +67,6 @@ void UVoltSubsystem::TryDiscardAbandonedInstancesByInterval()
 void UVoltSubsystem::UpdateAnimations(float DeltaTime)
 {
 	
-	if(IsUtilizingMultithreading())
-	{
-		ModuleUpdateThread->TriggerTask(DeltaTime);
-	}
-
 	for (UVoltAnimationManager* AnimationManager : RegisteredAnimationManager)
 	{
 		if(AnimationManager == nullptr) continue;
@@ -79,6 +74,11 @@ void UVoltSubsystem::UpdateAnimations(float DeltaTime)
 		AnimationManager->Tick(DeltaTime);
 	}
 
+	if(IsUtilizingMultithreading())
+	{
+		ModuleUpdateThread->TriggerTask(DeltaTime);
+	}
+	
 	//UVolt_ASM_InterpColor* ColorInModule = ObjectInitializer.CreateDefaultSubobject<UVolt_ASM_InterpColor>(this,"ColorInterpIn");
 	//Modules.Add(ColorInModule);
 }

--- a/Source/VoltCore/Private/VoltVariableCollection.cpp
+++ b/Source/VoltCore/Private/VoltVariableCollection.cpp
@@ -21,7 +21,7 @@ UVoltVariableBase* UVoltVariableCollection::FindOrAddVariable(TSubclassOf<UVoltV
 UVoltVariableBase* UVoltVariableCollection::FindVariable(TSubclassOf<UVoltVariableBase> Type)
 {
 	if(!Type || !Type->IsValidLowLevel()) return nullptr;
-	
+
 	const int QueuedVariablesNum = QueuedVariables.Num();
 	for (int i = QueuedVariablesNum - 1; i >= 0; --i)
 	{

--- a/Source/VoltCore/Public/VoltAnimationTrack.h
+++ b/Source/VoltCore/Public/VoltAnimationTrack.h
@@ -31,10 +31,10 @@ public:
 public:
 	
 	UPROPERTY(BlueprintReadWrite, Category="Animation Track")
-	TScriptInterface<IVoltInterface> TargetSlateInterface;
+	TScriptInterface<IVoltInterface> TargetSlateInterface = nullptr;
 
 	UPROPERTY(BlueprintReadWrite, Category="Animation Track")
-	TSoftObjectPtr<UVoltAnimation> TargetAnimation;
+	TSoftObjectPtr<UVoltAnimation> TargetAnimation = nullptr;
 
 public:
 

--- a/Source/VoltCore/Public/VoltVariableCollection.h
+++ b/Source/VoltCore/Public/VoltVariableCollection.h
@@ -41,6 +41,9 @@ private:
 
 	UVoltVariableBase* EnqueueVariableOnQueue(UVoltVariableBase* Variable);
 
+	/**
+	 * Take QueuedVariables array and patch it to variables array. Please notice this action will be only done when volt update thread is halting, waiting for next update.
+	 */
 	void ProcessQueue();
 
 	friend UVoltAnimationManager;


### PR DESCRIPTION
Why didn't I notice this issue earlier? God.....

+ Fixed a fatal(Crashes) issue caused by the race condition of variable collection from lock-free read-write actions on a multithreaded environment.